### PR TITLE
Send approvers to SigningHub

### DIFF
--- a/lib/signing_flow.py
+++ b/lib/signing_flow.py
@@ -59,3 +59,17 @@ def get_signers(signflow_uri: str, query_method: Callable = query):
     } for r in records]
 
     return records
+
+def get_approvers(signflow_uri: str, query_method: Callable = query):
+    query_command = queries.signing_flow_approvers.construct(signflow_uri)
+    result = query_method(query_command)
+    records = query_result_helpers.to_recs(result)
+
+    records = [{
+        "email": r["approver"].replace("mailto:", ""),
+        "approval_activity": r["approval_activity"],
+        "start_date": r["start_date"],
+        "end_date": r["end_date"],
+    } for r in records]
+
+    return records

--- a/queries/__init__.py
+++ b/queries/__init__.py
@@ -1,3 +1,4 @@
 from . import signing_flow
 from . import signing_flow_pieces
 from . import signing_flow_signers
+from . import signing_flow_approvers

--- a/queries/signing_flow_approvers.py
+++ b/queries/signing_flow_approvers.py
@@ -1,0 +1,66 @@
+from string import Template
+from helpers import generate_uuid
+from escape_helpers import sparql_escape_uri, sparql_escape_string, sparql_escape_datetime
+from ..config import APPLICATION_GRAPH
+
+def construct(signflow_uri: str) -> str:
+    query_template = Template("""
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+
+SELECT DISTINCT ?approval_activity ?start_date ?end_date ?approver
+WHERE {
+    $signflow a sign:Handtekenaangelegenheid ;
+        sign:doorlooptHandtekening ?sign_subcase .
+    ?sign_subcase a sign:HandtekenProcedurestap ;
+        ^sign:goedkeuringVindtPlaatsTijdens ?approval_activity .
+    ?approval_activity a sign:Goedkeuringsactiviteit ;
+        sign:goedkeurder ?approver .
+    OPTIONAL {
+        ?approval_activity dossier:Activiteit.startdatum ?start_date .
+    }
+    OPTIONAL {
+        ?approval_activity dossier:Activiteit.einddatum ?end_date .
+    }
+}
+""")
+    return query_template.substitute(
+        signflow=sparql_escape_uri(signflow_uri)
+    )
+
+
+def construct_update_approval_activity_end_date(signflow_uri: str, email, end_date, graph=APPLICATION_GRAPH) -> str:
+    query_template = Template("""
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+
+DELETE {
+    GRAPH $graph {
+        ?signing_activity dossier:Activiteit.einddatum ?end_date .
+    }
+}
+INSERT {
+    GRAPH $graph {
+        ?signing_activity dossier:Activiteit.einddatum $end_date .
+    }
+}
+WHERE {
+    GRAPH $graph {
+        $signflow a sign:Handtekenaangelegenheid ;
+            sign:doorlooptHandtekening ?sign_subcase .
+        ?sign_subcase a sign:HandtekenProcedurestap ;
+            ^sign:goedkeuringVindtPlaatsTijdens ?signing_activity .
+        ?approval_activity a sign:Goedkeuringsactiviteit ;
+            sign:goedkeurder ?approver .
+        OPTIONAL {
+            ?approval_activity dossier:Activiteit.einddatum ?end_date .
+        }
+    }
+}
+""")
+    return query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        signflow=sparql_escape_uri(signflow_uri),
+        approver=sparql_escape_uri(email),
+        end_date=sparql_escape_datetime(end_date)
+    )


### PR DESCRIPTION
Stored approvers are sent to SigningHub.

I believe that the workflow order isn't set yet, i.e. the order of approving vs signing isn't configured for the signing flow, it's just the default serial order. This will be tackled later. 

Further PRs (like adding notifiers) will branch off this PR.