### PR TITLE
Feature/sync approvers status

### DIFF
--- a/agent_query.py
+++ b/agent_query.py
@@ -22,7 +22,7 @@ sparqlUpdate.addCustomHttpHeader('MU-AUTH-ALLOWED-GROUPS', json.dumps(DIGITAL_SI
 def query(the_query):
     """Execute the given SPARQL query (select/ask/construct)on the triple store and returns the results
     in the given returnFormat (JSON by default)."""
-    log("execute query: \n" + the_query)
+    log(f"(agent query) execute query: \n" + the_query)
     sparqlQuery.setQuery(the_query)
     return sparqlQuery.query().convert()
 
@@ -32,5 +32,5 @@ def update(the_query):
     if the given query is no update query, nothing happens."""
     sparqlUpdate.setQuery(the_query)
     if sparqlUpdate.isSparqlUpdateRequest():
-        log("execute query: \n" + the_query)
+        log("(agent update) execute query: \n" + the_query)
         sparqlUpdate.query()

--- a/lib/update_signing_flow.py
+++ b/lib/update_signing_flow.py
@@ -97,6 +97,8 @@ def sync_signers_status(sig_flow, sh_workflow_details):
     kaleidos_signers = get_signers(sig_flow, agent_query)
     logger.debug(f"Syncing signers status ...")
     for sh_workflow_user in sh_workflow_users:
+        if sh_workflow_user["role"] != "SIGNER":
+            continue
         proc_stat = sh_workflow_user["process_status"]
         logger.debug(f"Signer {sh_workflow_user['user_email']} has process status {proc_stat}.")
         if proc_stat == "UN_PROCESSED":

--- a/lib/update_signing_flow.py
+++ b/lib/update_signing_flow.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from flask import g
 from helpers import generate_uuid, logger
+from utils import pythonize_iso_timestamp
 from ..authentication import ensure_signinghub_machine_user_session
 from .signing_flow import get_signing_flow, get_signers, get_pieces, get_creator
 from .document import download_sh_doc_to_kaleidos_doc
@@ -62,7 +63,7 @@ def sync_signers_status(sig_flow, sh_workflow_details):
                 # elif proc_stat == "IN_PROGRESS":
                 if proc_stat == "SIGNED": # "REVIEWED",
                     logger.info(f"Signer {kaleidos_signer['email']} signed. Syncing ...")
-                    signing_time = sh_workflow_user["processed_on"]
+                    signing_time = pythonize_iso_timestamp(sh_workflow_user["processed_on"])
                     query_string = construct_update_signing_activity_end_date(
                         sig_flow,
                         kaleidos_signer["uri"],

--- a/lib/update_signing_flow.py
+++ b/lib/update_signing_flow.py
@@ -75,4 +75,4 @@ def sync_signers_status(sig_flow, sh_workflow_details):
             else:
                 logger.info(f"Signer {kaleidos_signer['email']} already has an end date in our db. No syncing needed.")
         else:
-            logger.info(f"Signer with e-mail address {kaleidos_signer['email']} not present in Kaleidos metadata: ignoring")
+            logger.info(f"Signer with e-mail address {sh_workflow_user['user_email']} not present in Kaleidos metadata: ignoring")

--- a/queries/signing_flow_approvers.py
+++ b/queries/signing_flow_approvers.py
@@ -29,6 +29,43 @@ WHERE {
     )
 
 
+def construct_update_approval_activity_start_date(signflow_uri: str, email, start_date, graph=APPLICATION_GRAPH) -> str:
+    query_template = Template("""
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+
+DELETE {
+    GRAPH $graph {
+        ?approval_activity dossier:Activiteit.startdatum ?start_date .
+    }
+}
+INSERT {
+    GRAPH $graph {
+        ?approval_activity dossier:Activiteit.startdatum $start_date .
+    }
+}
+WHERE {
+    GRAPH $graph {
+        $signflow a sign:Handtekenaangelegenheid ;
+            sign:doorlooptHandtekening ?sign_subcase .
+        ?sign_subcase a sign:HandtekenProcedurestap ;
+            ^sign:goedkeuringVindtPlaatsTijdens ?approval_activity .
+        ?approval_activity a sign:Goedkeuringsactiviteit ;
+            sign:goedkeurder $approver .
+        OPTIONAL {
+            ?approval_activity dossier:Activiteit.startdatum ?start_date .
+        }
+    }
+}
+""")
+    return query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        signflow=sparql_escape_uri(signflow_uri),
+        approver=sparql_escape_uri(email),
+        start_date=sparql_escape_datetime(start_date)
+    )
+
+
 def construct_update_approval_activity_end_date(signflow_uri: str, email, end_date, graph=APPLICATION_GRAPH) -> str:
     query_template = Template("""
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>

--- a/queries/signing_flow_approvers.py
+++ b/queries/signing_flow_approvers.py
@@ -36,12 +36,12 @@ PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
 
 DELETE {
     GRAPH $graph {
-        ?signing_activity dossier:Activiteit.einddatum ?end_date .
+        ?approval_activity dossier:Activiteit.einddatum ?end_date .
     }
 }
 INSERT {
     GRAPH $graph {
-        ?signing_activity dossier:Activiteit.einddatum $end_date .
+        ?approval_activity dossier:Activiteit.einddatum $end_date .
     }
 }
 WHERE {
@@ -49,9 +49,9 @@ WHERE {
         $signflow a sign:Handtekenaangelegenheid ;
             sign:doorlooptHandtekening ?sign_subcase .
         ?sign_subcase a sign:HandtekenProcedurestap ;
-            ^sign:goedkeuringVindtPlaatsTijdens ?signing_activity .
+            ^sign:goedkeuringVindtPlaatsTijdens ?approval_activity .
         ?approval_activity a sign:Goedkeuringsactiviteit ;
-            sign:goedkeurder ?approver .
+            sign:goedkeurder $approver .
         OPTIONAL {
             ?approval_activity dossier:Activiteit.einddatum ?end_date .
         }

--- a/queries/signing_flow_approvers.py
+++ b/queries/signing_flow_approvers.py
@@ -30,6 +30,9 @@ WHERE {
 
 
 def construct_update_approval_activity_start_date(signflow_uri: str, email, start_date, graph=APPLICATION_GRAPH) -> str:
+    if not email.startswith("mailto:"):
+        email = "mailto:" + email
+
     query_template = Template("""
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
@@ -67,6 +70,9 @@ WHERE {
 
 
 def construct_update_approval_activity_end_date(signflow_uri: str, email, end_date, graph=APPLICATION_GRAPH) -> str:
+    if not email.startswith("mailto:"):
+        email = "mailto:" + email
+
     query_template = Template("""
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>

--- a/queries/signing_flow_signers.py
+++ b/queries/signing_flow_signers.py
@@ -77,7 +77,6 @@ def construct_update_signing_activity_end_date(signflow_uri: str, mandatee_uri, 
     # isn't the same one as the one already bound to the signing activity (minister vs MP, ...)
     query_template = Template("""
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
-PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
 
 DELETE {

--- a/queries/signing_flow_signers.py
+++ b/queries/signing_flow_signers.py
@@ -72,6 +72,45 @@ WHERE {
         signflow=sparql_escape_uri(signflow_uri))
 
 
+def construct_update_signing_activity_start_date(signflow_uri: str, mandatee_uri, start_date, graph=APPLICATION_GRAPH) -> str:
+    # TODO: probably needs e-mail as input, since there is a chance that the mandatee retrieved by e-mail
+    # isn't the same one as the one already bound to the signing activity (minister vs MP, ...)
+    query_template = Template("""
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+
+DELETE {
+    GRAPH $graph {
+        ?signing_activity dossier:Activiteit.startdatum ?start_date .
+    }
+}
+INSERT {
+    GRAPH $graph {
+        ?signing_activity dossier:Activiteit.startdatum $start_date .
+    }
+}
+WHERE {
+    GRAPH $graph {
+        $signflow a sign:Handtekenaangelegenheid ;
+            sign:doorlooptHandtekening ?sign_subcase .
+        ?sign_subcase a sign:HandtekenProcedurestap ;
+            ^sign:handtekeningVindtPlaatsTijdens ?signing_activity .
+        ?signing_activity a sign:Handtekenactiviteit ;
+            sign:ondertekenaar $signer .
+        OPTIONAL {
+            ?signing_activity dossier:Activiteit.startdatum ?start_date .
+        }
+    }
+}
+""")
+    return query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        signflow=sparql_escape_uri(signflow_uri),
+        signer=sparql_escape_uri(mandatee_uri),
+        start_date=sparql_escape_datetime(start_date)
+    )
+
+
 def construct_update_signing_activity_end_date(signflow_uri: str, mandatee_uri, end_date, graph=APPLICATION_GRAPH) -> str:
     # TODO: probably needs e-mail as input, since there is a chance that the mandatee retrieved by e-mail
     # isn't the same one as the one already bound to the signing activity (minister vs MP, ...)

--- a/sudo_query.py
+++ b/sudo_query.py
@@ -12,7 +12,7 @@ sparqlUpdate.addCustomHttpHeader('mu-auth-sudo', 'true')
 def query(the_query):
     """Execute the given SPARQL query (select/ask/construct)on the triple store and returns the results
     in the given returnFormat (JSON by default)."""
-    log("execute query: \n" + the_query)
+    log("(sudo query) execute query: \n" + the_query)
     sparqlQuery.setQuery(the_query)
     return sparqlQuery.query().convert()
 
@@ -22,5 +22,5 @@ def update(the_query):
     if the given query is no update query, nothing happens."""
     sparqlUpdate.setQuery(the_query)
     if sparqlUpdate.isSparqlUpdateRequest():
-        log("execute query: \n" + the_query)
+        log("(sudo update) execute query: \n" + the_query)
         sparqlUpdate.query()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,20 @@
+import re
+
+def pythonize_iso_timestamp(timestamp):
+    """ Convert ISO 8601 timestamp to python .fromisoformat()-compliant format """
+    # 'Z'-timezone to '+00:00'-timezone
+    timestamp = timestamp.replace('Z', '+00:00')
+    # '+0000'-timezone to '+00:00'-timezone
+    def repl(matchobj):
+        sign = matchobj.group(1)
+        offset = matchobj.group(2)
+        hh, mm = offset[0:2], offset[2:4]
+        return "{}{}:{}".format(sign, hh, mm)
+    timestamp = re.sub(r'(\+|-)(\d{4})', repl, timestamp)
+    # '.39' microseconds to '.390000' microseconds
+    def repl2(matchobj):
+        ms = matchobj.group(1)
+        sign = matchobj.group(2)
+        return ".{}{}".format(ms[:6].ljust(6, '0'), sign)
+    timestamp = re.sub(r'\.(\d*)($|\+|-)', repl2, timestamp)
+    return timestamp

--- a/web.py
+++ b/web.py
@@ -22,9 +22,11 @@ def sync_all_ongoing_flows():
     for id in ids:
         requests.post(f"http://localhost/signing-flows/{id}/sync")
 
-scheduler = BackgroundScheduler()
-scheduler.add_job(sync_all_ongoing_flows, CronTrigger.from_crontab(SYNC_CRON_PATTERN))
-scheduler.start()
+from werkzeug.serving import is_running_from_reloader
+if is_running_from_reloader():
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(sync_all_ongoing_flows, CronTrigger.from_crontab(SYNC_CRON_PATTERN))
+    scheduler.start()
 
 @app.route("/verify-credentials")
 def sh_profile_info():

--- a/web.py
+++ b/web.py
@@ -22,11 +22,9 @@ def sync_all_ongoing_flows():
     for id in ids:
         requests.post(f"http://localhost/signing-flows/{id}/sync")
 
-from werkzeug.serving import is_running_from_reloader
-if is_running_from_reloader():
-    scheduler = BackgroundScheduler()
-    scheduler.add_job(sync_all_ongoing_flows, CronTrigger.from_crontab(SYNC_CRON_PATTERN))
-    scheduler.start()
+scheduler = BackgroundScheduler()
+scheduler.add_job(sync_all_ongoing_flows, CronTrigger.from_crontab(SYNC_CRON_PATTERN))
+scheduler.start()
 
 @app.route("/verify-credentials")
 def sh_profile_info():


### PR DESCRIPTION
Syncs approvers' state (activity start and end dates) as well as signing-activities' start dates.

End dates are taken from the `processed_on` field from the API, as defined in spec. Start dates are based on the `modified_on` field in the top level response from the API. The idea being that the last modified date shows when the flow was shared or last accepted by a reviewer.

Also makes some small changes to the query functions' logging, we now log which function is being executed, so we can differentiate agent from sudo queries at a glance.