### PR TITLE
Feature/signinghub multiple documents

### DIFF
--- a/lib/document.py
+++ b/lib/document.py
@@ -37,6 +37,7 @@ def upload_piece_to_sh(piece_uri, signinghub_package_id=None):
     file_record = query_result_helpers.ensure_1(file_records)
     file_path = file_record["physicalFile"]
     file_name = fs_sanitize_filename(doc_record["name"] + "." + file_record["extension"])
+    file_name = file_name.strip()  # SH fails on uploads containing leading whitespace
 
     file_path = file_path.replace("share://", "/share/")
     with open(file_path, "rb") as f:

--- a/lib/generic.py
+++ b/lib/generic.py
@@ -4,7 +4,7 @@ from helpers import query
 from .query_result_helpers import to_recs, ensure_1
 from escape_helpers import sparql_escape_uri, sparql_escape_string
 
-def get_by_uuid(uuid: str, rdf_type=None, query_method: Callable = query):
+def get_by_uuid(uuid: str, rdf_type=None, query_method: Callable = query) -> str:
     query_template = Template("""
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 

--- a/lib/kaleidos_document_name.py
+++ b/lib/kaleidos_document_name.py
@@ -1,0 +1,54 @@
+import datetime
+import re
+
+NUMBERS_BY_LATIN_ADVERBIALS = {
+    '': 1,
+    'bis': 2,
+    'ter': 3,
+    'quater': 4,
+    'quinquies': 5,
+    'sexies': 6,
+    'septies': 7,
+    'octies': 8,
+    'novies': 9,
+    'decies': 10,
+    'undecies': 11,
+    'duodecies': 12,
+    'ter decies': 13,
+    'quater decies': 14,
+    'quindecies': 15,
+}
+
+REGEXES = {
+    'date': r'(?P<date>[12][90][0-9]{2} [0-3][0-9][01][0-9])',
+    'casePrefix': r'(?P<casePrefix>( VV)|())',  # VV = Vlaamse Veerkracht
+    'docType': r'(?P<docType>(DOC)|(DEC)|(MED))',
+    'caseNr': r'(?P<caseNr>\d{4})',
+    'index': r'(?P<index>\d{1,3})',
+    'versionSuffix': rf'(?P<versionSuffix>({")|(".join(map(str.upper, NUMBERS_BY_LATIN_ADVERBIALS.keys()))}))'.replace('()|', ''),
+}
+
+DOC_NAME_REGEX = re.compile(rf'VR {REGEXES["date"]}{REGEXES["casePrefix"]} {REGEXES["docType"]}\.{REGEXES["caseNr"]}([/-]{REGEXES["index"]})?(.*?){REGEXES["versionSuffix"]}?$')
+
+
+def compare_piece_names(name1, name2) -> int:
+    def unix_time(s): return int(datetime.datetime.strptime(s, "%Y %d%m").timestamp())
+    def version(s): return NUMBERS_BY_LATIN_ADVERBIALS[s.lower()] if s else 1
+
+    m1 = DOC_NAME_REGEX.match(name1)
+    m2 = DOC_NAME_REGEX.match(name2)
+    if m1 and m2:
+        return ((int(m2.group("caseNr")) - int(m1.group("caseNr"))) or  # Case number descending (newest first)
+                (int(m1.group("index")) - int(m2.group("index")) or  # Index ascending
+                (unix_time(m2.group("date")) - unix_time(m1.group("date"))) or  # Date descending (newest first)
+                (version(m2.group("versionSuffix")) - version(m1.group("versionSuffix")))))  # versionNumber descending (newest first)
+    elif m1:
+        return -1
+    elif m2:
+        return 1
+    elif name1 == name2:
+        return 0
+    elif name1 < name2:
+        return -1
+    else:
+        return 1

--- a/lib/prepare_signing_flow.py
+++ b/lib/prepare_signing_flow.py
@@ -1,92 +1,93 @@
+import itertools
 from string import Template
-import typing
-from flask import g
+from typing import Dict, List
 from signinghub_api_client.client import SigningHubSession
-from helpers import generate_uuid, query, update, logger
+from helpers import generate_uuid, update, logger
 from escape_helpers import sparql_escape_uri, sparql_escape_string
-from . import exceptions, query_result_helpers, uri, signing_flow
+from . import uri, signing_flow
 from .mandatee import get_mandatee
 from .document import upload_piece_to_sh
 from ..config import APPLICATION_GRAPH
-from ..queries.signing_flow_pieces import construct_get_decision_report
 
-# TODO:
-# validation:
-# - document is not uploaded yet
-def prepare_signing_flow(signinghub_session: SigningHubSession,
-                     signflow_uri: str,
-                     piece_uris: typing.List[str]):
-    if len(piece_uris) == 0:
-        raise exceptions.InvalidArgumentException(f"No piece to add specified.")
-    if len(piece_uris) > 1:
-        raise exceptions.InvalidArgumentException(f"Signflow can only add 1 piece.")
-    piece_uri = piece_uris[0]
+def group_by_decision_activity(sign_flows: List[Dict]):
+    # TODO: Cope with the fact that at some point we need to support
+    # optional decision activities
+    get_decision_activity = lambda d: d["decision_activity"]
+    return [list(g) for _, g in itertools.groupby(sign_flows, get_decision_activity)]
 
-    pieces = signing_flow.get_pieces(signflow_uri)
-    piece = query_result_helpers.ensure_1(pieces)
-    if piece["uri"] != piece_uri:
-        raise exceptions.InvalidStateException(f"Piece {piece_uri} is not associated to signflow {signflow_uri}.")
+def prepare_signing_flow(sh_session: SigningHubSession, sign_flows: List[Dict]):
+    """Prepares a signing flow in SigningHub based off multiple sign flows in Kaleidos."""
+    for grouped_sign_flows in group_by_decision_activity(sign_flows):
+        signinghub_package = sh_session.add_package({
+            "workflow_mode": "ONLY_OTHERS" # OVRB staff who prepare the flows will never sign
+        })
+        package_id = signinghub_package["package_id"]
 
-    # Beslissingfiche
-    decision_report_query = construct_get_decision_report(signflow_uri)
-    decision_report_query_result = query_result_helpers.ensure_0_or_1(
-                                       query_result_helpers.to_recs(query(decision_report_query)))
-    signinghub_package_id = None
-    if decision_report_query_result:
-        _, signinghub_package_id, _ = upload_piece_to_sh(decision_report_query_result["decision_report"])
+        sign_flow = grouped_sign_flows[0]["sign_flow"]
+        decision_report = grouped_sign_flows[0]["decision_report"]
+        if decision_report:
+            upload_piece_to_sh(decision_report, package_id)
 
-    # Document
-    signinghub_document_uri, signinghub_package_id, _ = upload_piece_to_sh(piece_uri, signinghub_package_id)
+        sh_session.update_workflow_details(package_id, {"workflow_type": "CUSTOM"})
 
-    preparation_activity_id = generate_uuid()
-    preparation_activity_uri = uri.resource.preparation_activity(preparation_activity_id)
+        # All sign flows we're treating *should* have the same
+        # approvers/notification/signers, so it's okay to use the first
+        # sign flow to get them.
+        approvers = signing_flow.get_approvers(sign_flow)
+        for approver in approvers:
+            logger.info(f"adding approver {approver['email']} to flow")
+            sh_session.add_users_to_workflow(package_id, [{
+            "user_email": approver["email"],
+            "user_name": approver["email"],
+            "role": "REVIEWER",
+            "email_notification": True,
+            "signing_order": 1,
+        }])
 
-    query_string = _update_template.substitute(
-        graph=sparql_escape_uri(APPLICATION_GRAPH),
-        signflow=sparql_escape_uri(signflow_uri),
-        preparation_activity=sparql_escape_uri(preparation_activity_uri),
-        preparation_activity_id=sparql_escape_string(preparation_activity_id),
-        sh_document=sparql_escape_uri(signinghub_document_uri),
-    )
-    update(query_string)
+        notified = signing_flow.get_notified(sign_flow)
+        for notify in notified:
+            logger.info(f"adding notified {notify['email']} to flow")
+            sh_session.add_users_to_workflow(package_id, [{
+            "user_email": notify["email"],
+            "user_name": notify["email"],
+            "role": "CARBON_COPY",
+            "email_notification": True,
+            "signing_order": 1,
+        }])
 
-    g.sh_session.update_workflow_details(signinghub_package_id, {
-      "workflow_type": "CUSTOM",
-    })
+        signers = signing_flow.get_signers(sign_flow)
+        for signer in signers:
+            logger.info(f"adding signer {signer['uri']} to flow")
+            signer = get_mandatee(signer["uri"])
+            sh_session.add_users_to_workflow(package_id, [{
+            "user_email": signer["email"],
+            "user_name": f"{signer['first_name']} {signer['family_name']}",
+            "role": "SIGNER",
+            "email_notification": True,
+            "signing_order": 2,
+        }])
 
-    approvers = signing_flow.get_approvers(signflow_uri)
-    for approver in approvers:
-        logger.info(f"adding approver {approver['email']} to flow")
-        g.sh_session.add_users_to_workflow(signinghub_package_id, [{
-          "user_email": approver["email"],
-          "user_name": approver["email"],
-          "role": "REVIEWER",
-          "email_notification": True,
-          "signing_order": 1,
-       }])
+        for sign_flow in grouped_sign_flows:
+            sign_flow_uri = sign_flow["sign_flow"]
+            piece_uri = sign_flow["piece"]
 
-    notified = signing_flow.get_notified(signflow_uri)
-    for notify in notified:
-        logger.info(f"adding notified {notify['email']} to flow")
-        g.sh_session.add_users_to_workflow(signinghub_package_id, [{
-          "user_email": notify["email"],
-          "user_name": notify["email"],
-          "role": "CARBON_COPY",
-          "email_notification": True,
-          "signing_order": 1,
-       }])
+            # Document
+            signinghub_document_uri, _, _ = upload_piece_to_sh(piece_uri, package_id)
 
-    signers = signing_flow.get_signers(signflow_uri)
-    for signer in signers:
-        logger.info(f"adding signer {signer['uri']} to flow")
-        signer = get_mandatee(signer["uri"])
-        g.sh_session.add_users_to_workflow(signinghub_package_id, [{
-          "user_email": signer["email"],
-          "user_name": f"{signer['first_name']} {signer['family_name']}",
-          "role": "SIGNER",
-          "email_notification": True,
-          "signing_order": 2,
-       }])
+            preparation_activity_id = generate_uuid()
+            preparation_activity_uri = uri.resource.preparation_activity(preparation_activity_id)
+
+            query_string = _update_template.substitute(
+                graph=sparql_escape_uri(APPLICATION_GRAPH),
+                signflow=sparql_escape_uri(sign_flow_uri),
+                preparation_activity=sparql_escape_uri(preparation_activity_uri),
+                preparation_activity_id=sparql_escape_string(preparation_activity_id),
+                sh_document=sparql_escape_uri(signinghub_document_uri),
+            )
+            update(query_string)
+
+    return
+
 
 # optional sign activities to link in case some were already created before sending to SH
 _update_template = Template("""
@@ -103,12 +104,16 @@ INSERT {
         $preparation_activity sign:voorbereidingGenereert $sh_document .
         ?signing_activity prov:wasInformedBy $preparation_activity .
         ?approval_activity sign:isGoedgekeurdDoor $preparation_activity .
+        $preparation_activity sign:isGemarkeerdDoor ?marking_activity .
     }
 } WHERE {
     GRAPH $graph {
         $signflow a sign:Handtekenaangelegenheid ;
             sign:doorlooptHandtekening ?sign_subcase .
         ?sign_subcase a sign:HandtekenProcedurestap .
+        OPTIONAL {
+            ?marking_activity sign:markeringVindtPlaatsTijdens ?sign_subcase .
+        }
         OPTIONAL {
             ?signing_activity sign:handtekeningVindtPlaatsTijdens ?sign_subcase .
         }

--- a/lib/query_result_helpers.py
+++ b/lib/query_result_helpers.py
@@ -1,7 +1,8 @@
 import collections
+from typing import Any, DefaultDict, Dict, List, Optional
 from . import exceptions
 
-def to_recs(result):
+def to_recs(result: Dict) -> List[DefaultDict]:
     bindings = result["results"]["bindings"]
     return [
         collections.defaultdict(
@@ -10,16 +11,16 @@ def to_recs(result):
         ])
     for b in bindings]
 
-def to_answer(result):
+def to_answer(result: Dict):
     return result["boolean"]
 
-def ensure_0_or_1(collection):
+def ensure_0_or_1(collection: List[Any]) -> Optional[Any]:
     if len(collection) > 1:
         raise exceptions.InvalidStateException(f"expected: 1 - found: {len(collection)}")
     elif len(collection) == 1:
         return collection[0]
 
-def ensure_1(collection):
+def ensure_1(collection: List[Any]) -> Any:
     if len(collection) != 1:
         raise exceptions.InvalidStateException(f"expected: 1 - found: {len(collection)}")
     return collection[0]

--- a/queries/signing_flow.py
+++ b/queries/signing_flow.py
@@ -159,8 +159,11 @@ def construct_get_signing_flows_by_uuids(ids: List[str]) -> str:
     PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
     PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
     PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+    PREFIX dct: <http://purl.org/dc/terms/>
 
-    SELECT DISTINCT ?id ?sign_flow ?piece ?decision_activity ?decision_report
+    SELECT DISTINCT ?id ?sign_flow
+        ?piece ?piece_name ?piece_created
+        ?decision_activity ?decision_report
     WHERE {
         VALUES ?id { $ids }
         ?sign_flow a sign:Handtekenaangelegenheid ;
@@ -170,6 +173,8 @@ def construct_get_signing_flows_by_uuids(ids: List[str]) -> str:
         ?marking_activity a sign:Markeringsactiviteit ;
             sign:markeringVindtPlaatsTijdens ?sign_subcase ;
             sign:gemarkeerdStuk ?piece .
+        ?piece dct:title ?piece_name ;
+               dct:created ?piece_created .
 
         OPTIONAL {
             ?sign_flow sign:heeftBeslissing ?decision_activity .

--- a/queries/signing_flow.py
+++ b/queries/signing_flow.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from string import Template
+from typing import List
 from helpers import generate_uuid
 from escape_helpers import sparql_escape_uri, sparql_escape_string, sparql_escape_datetime
 from ..config import ANNULATIEACTIVITEIT_RESOURCE_BASE_URI
@@ -149,4 +150,37 @@ def construct_insert_cancellation_activity(sign_flow: str, date = None) -> str:
         cancellation_activity=sparql_escape_uri(uri),
         cancellation_activity_id=sparql_escape_string(uuid),
         date=sparql_escape_datetime(date),
+    )
+
+
+def construct_get_signing_flows_by_uuids(ids: List[str]) -> str:
+    query_template = Template("""
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+    PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+    PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+
+    SELECT DISTINCT ?id ?sign_flow ?piece ?decision_activity ?decision_report
+    WHERE {
+        VALUES ?id { $ids }
+        ?sign_flow a sign:Handtekenaangelegenheid ;
+            mu:uuid ?id ;
+            sign:doorlooptHandtekening ?sign_subcase .
+        ?sign_subcase a sign:HandtekenProcedurestap .
+        ?marking_activity a sign:Markeringsactiviteit ;
+            sign:markeringVindtPlaatsTijdens ?sign_subcase ;
+            sign:gemarkeerdStuk ?piece .
+
+        OPTIONAL {
+            ?sign_flow sign:heeftBeslissing ?decision_activity .
+            ?decision_activity a besluitvorming:Beslissingsactiviteit .
+            OPTIONAL {
+                ?decision_report a dossier:Stuk ;
+                    besluitvorming:beschrijft ?decision_activity .
+            }
+        }
+    }
+    """)
+    return query_template.substitute(
+        ids=" ".join(list(map(sparql_escape_string, ids))),
     )

--- a/web.py
+++ b/web.py
@@ -4,7 +4,7 @@ import requests
 from flask import g, request, make_response
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
-from helpers import log, error, logger, update
+from helpers import log, error, logger, query
 from lib.query_result_helpers import ensure_1, to_recs
 from .queries.signing_flow import construct_get_signing_flows_by_uuids
 
@@ -52,8 +52,8 @@ def prepare_post():
 
     sign_flow_ids = [entry["id"] for entry in body["data"]]
 
-    query = construct_get_signing_flows_by_uuids(sign_flow_ids)
-    sign_flows = to_recs(agent_query(query))
+    query_string = construct_get_signing_flows_by_uuids(sign_flow_ids)
+    sign_flows = to_recs(query(query_string))
 
     prepare_signing_flow.prepare_signing_flow(g.sh_session, sign_flows)
 


### PR DESCRIPTION
Updates the `/upload-to-signinghub` endpoint to accept multiple sign flow IDs and do a bundled upload per decision activity.
We fetch the sign flows, their decision activity and piece (URIs), and then group them by decision activity. For each group we create a package in SH, upload the decision report (if it exists), add the singers, approvers, and notifiers and then finally upload the sign flows' pieces.

I have also deleted some of the unused endpoints here, to make the code a little clearer. There's still more we can potentially delete if desired, or we can bring back the unused code if we don't want to throw it away. There's also some changes to the type annotations of the helpers. We can throw these away if desired, they're not needed for this PR.