### PR TITLE
Feature/kas 111 beslissingsfiche klaarmaken voor digitaal ondertekenen

### DIFF
--- a/web.py
+++ b/web.py
@@ -56,6 +56,11 @@ def prepare_post():
     query_string = construct_get_signing_flows_by_uuids(sign_flow_ids)
     sign_flows = to_recs(query(query_string))
 
+    # Remove decision_report when it's equal to piece
+    for sign_flow in sign_flows:
+        if sign_flow["piece"] == sign_flow["decision_report"]:
+            sign_flow["decision_report"] = None
+
     prepare_signing_flow.prepare_signing_flow(g.sh_session, sign_flows)
 
     res = make_response("", 204)


### PR DESCRIPTION
When the decision report is the same as the piece we're trying to start a sign flow for, don't include the decision report as a "voorblad". We do this by making it `None`, so that the code down the line doesn't try to include it in the call to SigningHub.