### PR TITLE
chore: return an error when an unhandled exception is raised

### DIFF
--- a/authentication.py
+++ b/authentication.py
@@ -67,7 +67,7 @@ def signinghub_session_required(f):
             return error(ex.args[0])
         except Exception as ex:
             logger.exception("Unknown error during SH login")
-            raise ex
+            return error(str(ex), status=500)
 
     return decorated_function
 


### PR DESCRIPTION
If we just raise the exception, the service freaks out and returns nothing, which isn't very helpful. By returning an error we actually get an error in the frontend that we can at least show and have users send back to us.

![image](https://github.com/kanselarij-vlaanderen/digital-signing-service/assets/22411874/9887456f-8e54-4858-a8f0-5cf10a5b18b4)

![image](https://github.com/kanselarij-vlaanderen/digital-signing-service/assets/22411874/4d3709ad-e603-4b14-91c2-1d4e3236ff97)

