### PR TITLE
Feature/kas 4379 bundle BFs and minutes

### DIFF
--- a/queries/signing_flow.py
+++ b/queries/signing_flow.py
@@ -143,6 +143,7 @@ PREFIX dct: <http://purl.org/dc/terms/>
 SELECT DISTINCT ?id ?sign_flow
     ?piece ?piece_name ?piece_created
     ?decision_activity ?decision_report
+    ?meeting
 WHERE {
     VALUES ?id { $ids }
     ?sign_flow a sign:Handtekenaangelegenheid ;
@@ -163,6 +164,7 @@ WHERE {
                 besluitvorming:beschrijft ?decision_activity .
         }
     }
+    OPTIONAL { ?sign_flow sign:heeftVergadering ?meeting . }
 }
 """)
     return query_template.substitute(


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4379

Sign flows are now optionally linked to meetings. This is the case of sign flows of reports or minutes. We support this when grouping pieces together for sending to SH. If multiple pieces belong to the same meeting, they will be bundled together. This should mean that all reports and minutes of a single meeting should be a single SH bundle for the secretary of the ministerial council.

In the case of regular pieces, we still group them by decision activity (i.e. per agenda item), because they should not get linked to a meeting.