### PR TITLE
Feature/KAS-4424: Use job approach for uploading sign flows to SigningHub

### DIFF
--- a/authentication.py
+++ b/authentication.py
@@ -83,10 +83,8 @@ def open_new_signinghub_machine_user_session(ovo_code, scope=None):
     account_details = MACHINE_ACCOUNTS[ovo_code]
     sh_session.authenticate(account_details["API_CLIENT_ID"],
                             account_details["API_CLIENT_SECRET"],
-                            "password", # grant type
-                            account_details["USERNAME"],
-                            account_details["PASSWORD"],
-                            scope)
+                            grant_type="client_credentials",
+                            scope=scope)
     return sh_session
 
 def ensure_signinghub_machine_user_session(scope=None):

--- a/authentication.py
+++ b/authentication.py
@@ -26,8 +26,7 @@ CLIENT_CERT_AUTH_ENABLED = CERT_FILE_PATH and KEY_FILE_PATH
 
 SIGNINGHUB_SESSION_BASE_URI = KALEIDOS_RESOURCE_BASE_URI + "id/signinghub-sessions/"
 
-def ensure_signinghub_session(mu_session_uri):
-    """For api interactions made through Kaleidos initiated by a user"""
+def get_or_create_signinghub_session(mu_session_uri):
     mu_session_query = construct_get_mu_session_query(mu_session_uri)
     mu_session_result = sudo_query(mu_session_query)['results']['bindings']
     if not mu_session_result:
@@ -35,13 +34,14 @@ def ensure_signinghub_session(mu_session_uri):
     mu_session = mu_session_result[0]
     sh_session_query = construct_get_signinghub_session_query(mu_session_uri)
     sh_session_results = sudo_query(sh_session_query)['results']['bindings']
+    sh_session = None
     if sh_session_results: # Restore SigningHub session
         log("Found a valid SigningHub session.")
         sh_session_result = sh_session_results[0]
-        g.sh_session = SigningHubSession(SIGNINGHUB_API_URL)
+        sh_session = SigningHubSession(SIGNINGHUB_API_URL)
         if CLIENT_CERT_AUTH_ENABLED:
-            g.sh_session.cert = (CERT_FILE_PATH, KEY_FILE_PATH) # For authenticating against VO-network
-        g.sh_session.access_token = sh_session_result["token"]["value"]
+            sh_session.cert = (CERT_FILE_PATH, KEY_FILE_PATH) # For authenticating against VO-network
+        sh_session.access_token = sh_session_result["token"]["value"]
     else: # Open new SigningHub session
         log("No valid SigningHub session found. Opening a new one ...")
         sh_session = open_new_signinghub_machine_user_session(mu_session["ovoCode"]["value"], mu_session["email"]["value"])
@@ -50,7 +50,12 @@ def ensure_signinghub_session(mu_session_uri):
         sudo_update(sh_session_query)
         sh_session_link_query = construct_attach_signinghub_session_to_mu_session_query(sh_session_uri, mu_session_uri)
         sudo_update(sh_session_link_query)
-        g.sh_session = sh_session
+    return sh_session
+
+def ensure_signinghub_session(mu_session_uri):
+    """For api interactions made through Kaleidos initiated by a user"""
+    sh_session = get_or_create_signinghub_session(mu_session_uri)
+    g.sh_session = sh_session
 
 def signinghub_session_required(f):
     @wraps(f)

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ from pytz import timezone
 # Config
 KALEIDOS_RESOURCE_BASE_URI = "http://themis.vlaanderen.be/"
 SIGNINGHUB_RESOURCE_BASE_URI = os.environ.get("SIGNINGHUB_API_URL", KALEIDOS_RESOURCE_BASE_URI).strip("/") + "/"
+JOB_RESOURCE_BASE_URI = "http://mu.semte.ch/services/digital-signing/prepare-signing-flow-job/"
 TIMEZONE = timezone('Europe/Brussels')
 SYNC_CRON_PATTERN = os.environ.get("SYNC_CRON_PATTERN", "*/2 * * * *")
 SIGNINGHUB_APP_DOMAIN = os.environ.get("SIGNINGHUB_APP_DOMAIN")
@@ -14,6 +15,16 @@ APPLICATION_GRAPH = "http://mu.semte.ch/application"
 ACCESS_LEVEL_CABINET = "http://themis.vlaanderen.be/id/concept/toegangsniveau/13ae94b0-6188-49df-8ecd-4c4a17511d6d"
 ACCESS_LEVEL_GOVERNMENT = "http://themis.vlaanderen.be/id/concept/toegangsniveau/634f438e-0d62-4ae4-923a-b63460f6bc46"
 ACCESS_LEVEL_PUBLIC = "http://themis.vlaanderen.be/id/concept/toegangsniveau/c3de9c70-391e-4031-a85e-4b03433d6266"
+
+
+JOB = {
+    "STATUSES": {
+        "SCHEDULED": "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+        "BUSY": "http://redpencil.data.gift/id/concept/JobStatus/busy",
+        "SUCCESS": "http://redpencil.data.gift/id/concept/JobStatus/success",
+        "FAILED": "http://redpencil.data.gift/id/concept/JobStatus/failed",
+    },
+}
 
 GOEDKEURINGSACTIVITEIT_RESOURCE_BASE_URI = f"{KALEIDOS_RESOURCE_BASE_URI}id/handteken-goedkeuringsactiviteit/"
 WEIGERACTIVITEIT_RESOURCE_BASE_URI = f"{KALEIDOS_RESOURCE_BASE_URI}id/handteken-weigeractiviteit/"

--- a/lib/job.py
+++ b/lib/job.py
@@ -1,0 +1,215 @@
+from config import APPLICATION_GRAPH, JOB, JOB_RESOURCE_BASE_URI
+from escape_helpers import (
+    sparql_escape_string,
+    sparql_escape_uri,
+    sparql_escape_datetime,
+)
+from helpers import generate_uuid, logger, update, query
+
+from datetime import datetime
+from string import Template
+
+from ..authentication import get_or_create_signinghub_session
+from ..agent_query import query as agent_query, update as agent_update
+from .file import delete_physical_file
+from .prepare_signing_flow import prepare_signing_flow
+from .query_result_helpers import to_recs
+from ..queries.signing_flow import (
+    construct_get_signing_flows_by_uris,
+    get_physical_files_of_sign_flows,
+    reset_signflows,
+)
+
+
+def create_job(sign_flow_uris, mu_session_uri):
+    uuid = generate_uuid()
+    uri = f"{JOB_RESOURCE_BASE_URI}{uuid}"
+    now = datetime.now()
+    logger.info(
+        f"Creating job with uri {sparql_escape_uri(uri)} for {len(sign_flow_uris)} sign flows"
+    )
+
+    query_string = Template(
+        """PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+INSERT DATA {
+    GRAPH $graph {
+        $uri a ext:PrepareSignFlowJob ;
+            mu:uuid $uuid ;
+            prov:used $sign_flow_uris ;
+            adms:status $status ;
+            dct:creator $mu_session_uri ;
+            dct:created $created ;
+            dct:modified $modified .
+    }
+}"""
+    ).substitute(
+        graph=sparql_escape_uri(APPLICATION_GRAPH),
+        uri=sparql_escape_uri(uri),
+        uuid=sparql_escape_string(uuid),
+        sign_flow_uris=", ".join(map(sparql_escape_uri, sign_flow_uris)),
+        status=sparql_escape_uri(JOB["STATUSES"]["SCHEDULED"]),
+        mu_session_uri=sparql_escape_uri(mu_session_uri),
+        created=sparql_escape_datetime(now),
+        modified=sparql_escape_datetime(now),
+    )
+    update(query_string)
+
+    return {
+        "id": uuid,
+        "uri": uri,
+        "sign_flow_uris": sign_flow_uris,
+        "mu_session_uri": mu_session_uri,
+        "created": now,
+        "modified": now,
+        "status": JOB["STATUSES"]["SCHEDULED"],
+    }
+
+def get_job(uuid):
+    query_string = Template(
+        """PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+SELECT ?uri ?status ?sign_flow_uris ?created ?modified ?error_message
+WHERE {
+  GRAPH $graph {
+    ?uri a ext:PrepareSignFlowJob ;
+      mu:uuid $uuid ;
+      prov:used ?sign_flow_uris ;
+      dct:creator ?mu_session_uri ;
+      dct:created ?created ;
+      dct:modified ?modified ;
+      adms:status ?status .
+    OPTIONAL { ?uri ext:errorMessage ?error_message }
+  }
+} ORDER BY ASC(?created) LIMIT 1"""
+    ).substitute(
+        graph=sparql_escape_uri(APPLICATION_GRAPH),
+        uuid=sparql_escape_string(uuid),
+    )
+
+    result = query(query_string)
+    records = to_recs(result)
+    if len(records):
+        record = records[0]
+        return {
+            "id": uuid,
+            "uri": record["uri"],
+            "sign_flow_uris": record["sign_flow_uris"],
+            "mu_session_uri": record["mu_session_uri"],
+            "created": record["created"],
+            "modified": record["modified"],
+            "status": record["status"],
+            "error_message": record["error_message"],
+        }
+    return None
+
+
+def update_job_status(job_uri, status_uri):
+    now = datetime.now()
+    query_string = Template(
+        """PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+DELETE WHERE {
+  $job_uri dct:modified ?modified ;
+           adms:status ?status.
+}
+;
+INSERT DATA {
+  $job_uri dct:modified $now;
+           adms:status $status_uri.
+}"""
+    ).substitute(
+        job_uri=sparql_escape_uri(job_uri),
+        status_uri=sparql_escape_uri(status_uri),
+        now=sparql_escape_datetime(now),
+    )
+    agent_update(query_string)
+
+
+def update_job_error_message(job_uri, error_message):
+    now = datetime.now()
+    query_string = Template(
+        """PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE WHERE {
+  $job_uri dct:modified ?modified ;
+           ext:errorMessage ?errorMessage.
+}
+;
+INSERT DATA {
+  $job_uri dct:modified $now;
+           ext:errorMessage $error_message.
+}"""
+    ).substitute(
+        job_uri=sparql_escape_uri(job_uri),
+        error_message=sparql_escape_string(error_message),
+        now=sparql_escape_datetime(now),
+    )
+    agent_update(query_string)
+
+
+def execute_job(job):
+    try:
+        update_job_status(job["uri"], JOB["STATUSES"]["BUSY"])
+        execute_prepare_sign_flow_job(job)
+        update_job_status(job["uri"], JOB["STATUSES"]["SUCCESS"])
+
+        logger.info("**************************************")
+        logger.info(f"Successfully finished job <{job['uri']}>")
+        logger.info("**************************************")
+    except Exception as e:
+        logger.exception(f"Execution of job <{job['uri']}> failed:")
+        update_job_status(job["uri"], JOB["STATUSES"]["FAILED"])
+        error_message = str(e)
+        update_job_error_message(
+            job["uri"],
+            str(
+                {
+                    "errors": [
+                        {
+                            "detail": error_message,
+                            "status": 500,
+                        }
+                    ]
+                }
+            ),
+        )
+
+
+def execute_prepare_sign_flow_job(job):
+    mu_session_uri = job["mu_session_uri"]
+    sign_flow_uris = job["sign_flow_uris"]
+    query_string = construct_get_signing_flows_by_uris(sign_flow_uris)
+    sign_flows = to_recs(agent_query(query_string))
+
+    # Remove decision_report when it's equal to piece
+    for sign_flow in sign_flows:
+        if sign_flow["piece"] == sign_flow["decision_report"]:
+            sign_flow["decision_report"] = None
+
+    try:
+        sh_session = get_or_create_signinghub_session(mu_session_uri)
+        prepare_signing_flow(
+            sh_session,
+            sign_flows,
+            query_method=agent_query,
+            update_method=agent_update,
+        )
+    except Exception as exception:
+        physical_files = to_recs(
+            agent_query(get_physical_files_of_sign_flows(sign_flow_uris))
+        )
+        for physical_file in physical_files:
+            delete_physical_file(physical_file["uri"])
+        agent_update(reset_signflows(sign_flow_uris))
+        raise exception

--- a/lib/job.py
+++ b/lib/job.py
@@ -77,7 +77,7 @@ PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX adms: <http://www.w3.org/ns/adms#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 
-SELECT ?uri ?status ?sign_flow_uris ?created ?modified ?error_message
+SELECT ?uri ?status ?sign_flow_uris ?mu_session_uri ?created ?modified ?error_message
 WHERE {
   GRAPH $graph {
     ?uri a ext:PrepareSignFlowJob ;

--- a/lib/prepare_signing_flow.py
+++ b/lib/prepare_signing_flow.py
@@ -138,7 +138,7 @@ def prepare_signing_flow(
             piece_uri = sign_flow["piece"]
 
             # Document
-            signinghub_document_uri, _, signinghub_document_id = upload_piece_to_sh(piece_uri, package_id)
+            signinghub_document_uri, _, signinghub_document_id = upload_piece_to_sh(sh_session, piece_uri, package_id)
 
             # Auto-place signature field
             if ADD_SIGNATURE_FIELD_ENABLED:

--- a/queries/signing_flow.py
+++ b/queries/signing_flow.py
@@ -231,7 +231,7 @@ def get_physical_files_of_sign_flows_by_id(signflow_ids):
     }
     """)
     return query_template.substitute(
-        signflow_idss=" ".join(
+        signflow_ids=" ".join(
             list(map(sparql_escape_uri, signflow_ids))
         ),
     )
@@ -244,7 +244,7 @@ def reset_signflows(signflow_uris):
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX adms: <http://www.w3.org/ns/adms#>
-    
+
     DELETE {
         ?sign_flow adms:status ?status .
         ?sign_flow dct:creator ?creator .
@@ -259,7 +259,7 @@ def reset_signflows(signflow_uris):
             adms:status ?status ;
             dct:creator ?creator ;
             sign:doorlooptHandtekening ?sign_subcase .
-        ?marking_activity 
+        ?marking_activity
             sign:markeringVindtPlaatsTijdens ?sign_subcase ;
             sign:gemarkeerdStuk ?piece .
         {

--- a/queries/signing_flow.py
+++ b/queries/signing_flow.py
@@ -153,8 +153,8 @@ WHERE {
         sign:markeringVindtPlaatsTijdens ?sign_subcase ;
         sign:gemarkeerdStuk ?piece .
     ?piece dct:title ?piece_name ;
-        dct:created ?piece_created ;
-        ^dossier:Collectie.bestaatUit/dct:type ?piece_type .
+        dct:created ?piece_created .
+    OPTIONAL { ?piece ^dossier:Collectie.bestaatUit/dct:type ?piece_type . }
 
     OPTIONAL {
         ?sign_flow sign:heeftBeslissing ?decision_activity .

--- a/queries/signing_flow.py
+++ b/queries/signing_flow.py
@@ -132,7 +132,7 @@ WHERE {
     )
 
 
-def construct_get_signing_flows_by_uuids(ids: List[str]) -> str:
+def construct_get_signing_flows_by_uris(uris: List[str]) -> str:
     query_template = Template("""
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
@@ -145,7 +145,7 @@ SELECT DISTINCT ?id ?sign_flow
     ?decision_activity ?decision_report
     ?meeting
 WHERE {
-    VALUES ?id { $ids }
+    VALUES ?sign_flow { $uris }
     ?sign_flow a sign:Handtekenaangelegenheid ;
         mu:uuid ?id ;
         sign:doorlooptHandtekening ?sign_subcase .
@@ -168,12 +168,12 @@ WHERE {
 }
 """)
     return query_template.substitute(
-        ids=" ".join(list(map(sparql_escape_string, ids))),
+        uris=" ".join(list(map(sparql_escape_uri, uris))),
     )
 
 
 
-def get_physical_files_of_sign_flows(signflow_ids):
+def get_physical_files_of_sign_flows(signflow_uris):
     query_template = Template("""
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
@@ -182,7 +182,7 @@ def get_physical_files_of_sign_flows(signflow_ids):
 
     SELECT DISTINCT (?physical_file AS ?uri)
     WHERE {
-        VALUES ?id { $signflow_ids }
+        VALUES ?sign_flow { $signflow_uris }
 
         ?sign_flow a sign:Handtekenaangelegenheid ;
             mu:uuid ?id ;
@@ -199,13 +199,13 @@ def get_physical_files_of_sign_flows(signflow_ids):
     }
     """)
     return query_template.substitute(
-        signflow_ids=" ".join(
-            list(map(sparql_escape_string, signflow_ids))
+        signflow_uris=" ".join(
+            list(map(sparql_escape_uri, signflow_uris))
         ),
     )
 
 
-def reset_signflows(signflow_ids):
+def reset_signflows(signflow_uris):
     query_template = Template("""
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
@@ -220,7 +220,7 @@ def reset_signflows(signflow_ids):
     } INSERT {
         ?sign_flow adms:status <http://themis.vlaanderen.be/id/handtekenstatus/f6a60072-0537-11ee-bb35-ee395168dcf7> .
     } WHERE {
-        VALUES ?id { $signflow_ids }
+        VALUES ?sign_flow { $signflow_uris }
 
         ?sign_flow a sign:Handtekenaangelegenheid ;
             mu:uuid ?id ;
@@ -266,8 +266,8 @@ def reset_signflows(signflow_ids):
     }
     """)
     return query_template.substitute(
-        signflow_ids=" ".join(
-            list(map(sparql_escape_string, signflow_ids))
+        signflow_uris=" ".join(
+            list(map(sparql_escape_uri, signflow_uris))
         ),
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz
 apscheduler
 requests
-git+https://github.com/kanselarij-vlaanderen/signinghub-api-client.git@c0432437052c31f4652af5dbe130c83a28b531d9
+git+https://github.com/kanselarij-vlaanderen/signinghub-api-client.git@07d0d80e38358426b92d701f9283bbf44315a4be

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz
 apscheduler
 requests
-git+https://github.com/kanselarij-vlaanderen/signinghub-api-client.git@6d0dad54384f18f8ec86c77ee79adf93353749be
+git+https://github.com/kanselarij-vlaanderen/signinghub-api-client.git@c0432437052c31f4652af5dbe130c83a28b531d9

--- a/web.py
+++ b/web.py
@@ -74,12 +74,18 @@ def prepare_post():
     mu_session_id = request.headers["MU-SESSION-ID"]
 
     job = create_job(sign_flow_uris, mu_session_id)
-    del job["mu_session_uri"]
 
     thread = threading.Thread(target=lambda: execute_job(job))
     thread.start()
 
-    res = jsonify(job)
+    res = jsonify({
+            "id": job["id"],
+            "uri": job["uri"],
+            "sign_flow_uris": job["sign_flow_uris"],
+            "created": job["created"],
+            "modified": job["modified"],
+            "status": job["status"],
+    })
     res.headers["Content-Type"] = "application/vnd.api+json"
     return res
 


### PR DESCRIPTION
> [!WARNING]
> This PR is branched from https://github.com/kanselarij-vlaanderen/digital-signing-service/pull/35 as cleaning up the sign flows in the backend fits better into a job approach

https://kanselarij.atlassian.net/browse/KAS-4424

Adapts the logic of the `upload-to-signinghub` endpoint to create a job that gets immediately executed. The functions used have been adapted to perform agent queries (i.e. a query with the allowed groups of a logged in user) so that they still work under the job approach.

Jobs get executed immediately, there's no implementation of a "job runner" to queue up jobs and start them automatically because this replaces an endpoint where there was no need for separate running (i.e. before multiple users could use this endpoint at once, we don't need to now force them to work on a FIFO manner).