### PR TITLE
KAS-4596: Decreet as attachment on bekrachtiging

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,1 +1,3 @@
 DECISION_REPORT_TYPE_URI = "http://themis.vlaanderen.be/id/concept/document-type/e807feec-1958-46cf-a558-3379b5add49e"
+BEKRACHTIGING_TYPE_URI = "http://themis.vlaanderen.be/id/concept/document-type/609cf883-b52c-43fe-84b1-eed02527173b"
+DECREET_TYPE_URI = "https://data.vlaanderen.be/id/concept/AardWetgeving/Decreet"

--- a/lib/document.py
+++ b/lib/document.py
@@ -113,6 +113,9 @@ def upload_piece_to_sh(sh_session, piece_uri, sh_package_id=None, piece_type=Non
                 writer.write(bytes_stream)
                 bytes_stream.seek(0)
                 file_content = bytes_stream.read()
+        else:
+            with open(file_path, "rb") as f:
+                file_content = f.read()
     else:
         with open(file_path, "rb") as f:
             file_content = f.read()

--- a/lib/prepare_signing_flow.py
+++ b/lib/prepare_signing_flow.py
@@ -8,7 +8,9 @@ from escape_helpers import sparql_escape_string, sparql_escape_uri
 from helpers import generate_uuid, logger, query, update
 from signinghub_api_client.client import SigningHubSession
 
-from ..config import APPLICATION_GRAPH, ADD_SIGNATURE_FIELD_ENABLED, SIGNATURE_FIELD_WIDTH, SIGNATURE_FIELD_HEIGHT
+from ..config import (APPLICATION_GRAPH,
+                      ADD_SIGNATURE_FIELD_ENABLED,
+                      SIGNATURE_FIELD_WIDTH, SIGNATURE_FIELD_HEIGHT)
 from ..utils import pythonize_iso_timestamp
 from . import signing_flow, uri
 from .document import upload_piece_to_sh
@@ -138,7 +140,10 @@ def prepare_signing_flow(
             piece_uri = sign_flow["piece"]
 
             # Document
-            signinghub_document_uri, _, signinghub_document_id = upload_piece_to_sh(sh_session, piece_uri, package_id)
+            signinghub_document_uri, _, signinghub_document_id = upload_piece_to_sh(sh_session,
+                                                                                    piece_uri,
+                                                                                    package_id,
+                                                                                    sign_flow["piece_type"])
 
             # Auto-place signature field
             if ADD_SIGNATURE_FIELD_ENABLED:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytz
 apscheduler
 requests
+pypdf
 git+https://github.com/kanselarij-vlaanderen/signinghub-api-client.git@07d0d80e38358426b92d701f9283bbf44315a4be


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4596

Before sending the bekrachtiging to SigningHub, we create a new PDF where we add the decreet as an attachment.