### PR TITLE
fix: correctly use the order field in autoplace call

### DIFF
--- a/lib/prepare_signing_flow.py
+++ b/lib/prepare_signing_flow.py
@@ -185,14 +185,14 @@ def auto_place_signature(
         f"auto-placing signature field for "
         f"{piece_uri} {package_id} {signinghub_document_id}"
     ))
-    for mandatee in signer_mandatees:
+    for index, mandatee in enumerate(signer_mandatees):
         logger.info(f"placing field for signer {mandatee}")
         sh_data = {
             "search_text": (
                 f"{mandatee['first_name']} "
                 f"{mandatee['family_name']}"
             ),
-            "order": 1,
+            "order": index + 1,
             "field_type": "SIGNATURE",
             "level_of_assurance": ["QUALIFIED_ELECTRONIC_SIGNATURE"],
             "placement": "TOP",


### PR DESCRIPTION
If we always pass in "1", all signing fields will be assigned to the first signer we added. By doing it this way, we ensure that the fields are assigned in order.