### PR TITLE
KAS-4948: Retry flow polling with all sessions

### DIFF
--- a/authentication.py
+++ b/authentication.py
@@ -68,28 +68,6 @@ def open_new_signinghub_machine_user_session(ovo_code, scope=None):
                             scope=scope)
     return sh_session
 
-def ensure_signinghub_machine_user_session(scope=None):
-    """For interactions made by the service agent (initiated by cron job or similar)"""
-    sh_session_query = construct_get_signinghub_machine_user_session_query(scope)
-    sh_session_results = sudo_query(sh_session_query)['results']['bindings']
-    if sh_session_results: # Restore SigningHub session
-        log("Found a valid SigningHub session.")
-        sh_session_result = sh_session_results[0]
-        g.sh_session = SigningHubSession(SIGNINGHUB_API_URL)
-        if CLIENT_CERT_AUTH_ENABLED:
-            g.sh_session.cert = (CERT_FILE_PATH, KEY_FILE_PATH) # For authenticating against VO-network
-        g.sh_session.access_token = sh_session_result["token"]["value"]
-    else: # Open new SigningHub session
-        log("No valid SigningHub session found. Opening a new one ...")
-        ovo_code = sudo_query(construct_get_org_for_email(scope))['results']['bindings'][0]['ovoCode']['value']
-        sh_session = open_new_signinghub_machine_user_session(ovo_code, scope)
-        sh_session_uri = SIGNINGHUB_SESSION_BASE_URI + generate_uuid()
-        sh_session_query = construct_insert_signinghub_session_query(sh_session, sh_session_uri, scope)
-        sudo_update(sh_session_query)
-        sh_session_sudo_query = construct_mark_signinghub_session_as_machine_users_query(sh_session_uri)
-        sudo_update(sh_session_sudo_query)
-        g.sh_session = sh_session
-
 
 def set_signinghub_machine_user_session(session):
     log("Found a valid SigningHub session.")

--- a/lib/update_signing_flow.py
+++ b/lib/update_signing_flow.py
@@ -37,6 +37,7 @@ WRAP_UP_ACTIVITY_BASE_URI = KALEIDOS_RESOURCE_BASE_URI + "id/afrondingsactivitei
 
 def update_signing_flow(signflow_uri: str):
     signing_flow = get_signing_flow(signflow_uri, agent_query)
+    signing_flow["uri"] = signflow_uri
     creator = get_creator(signflow_uri, agent_query)
     """
     There are multiple paths here
@@ -85,6 +86,7 @@ def update_signing_flow(signflow_uri: str):
 
 def _update_signing_flow(signing_flow):
     sh_package_id = signing_flow["sh_package_id"]
+    signflow_uri = signing_flow["uri"]
     try:
         sh_workflow_details = g.sh_session.get_workflow_details(sh_package_id)
         logger.debug(f'Signing flow {signflow_uri}, workflow status {sh_workflow_details["workflow"]["workflow_status"]}')

--- a/queries/session.py
+++ b/queries/session.py
@@ -210,7 +210,6 @@ WHERE {
     }
 }
 ORDER BY DESC(?expiryTime)
-LIMIT 1
 """)
     if signinghub_scope:
         signinghub_scope_filter = f"?signinghubSession ext:scope {sparql_escape_string(signinghub_scope)} ."


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4948

Users can have multiple sessions and we currently don't have a way to determine which session is related to which signing flow (this is based on which OVO code was used to start the signing flow). So for now we will retry the polling with all the sessions we have, and if none work we will create new sessions for each OVO code and try with each.