### PR TITLE
KAS-4644: Clean up digital signing logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
-FROM semtech/mu-python-template:2.0.0-beta.1
+FROM sergiofenoll/mu-python-template:latest
+
+ENV LOG_SPARQL_ALL=false

--- a/agent_query.py
+++ b/agent_query.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from helpers import log
+from helpers import logger, LOG_SPARQL_QUERIES, LOG_SPARQL_UPDATES
 from SPARQLWrapper import JSON, SPARQLWrapper
 
 DIGITAL_SIGNING_AGENT_ALLOWED_GROUPS =   [ # Secretarie
@@ -26,9 +26,14 @@ sparqlUpdate.addCustomHttpHeader('MU-AUTH-ALLOWED-GROUPS', json.dumps(DIGITAL_SI
 def query(the_query):
     """Execute the given SPARQL query (select/ask/construct)on the triple store and returns the results
     in the given returnFormat (JSON by default)."""
-    log(f"(agent query) execute query: \n" + the_query)
+    if LOG_SPARQL_QUERIES:
+        logger.info("(AGENT) Execute query: \n" + the_query)
     sparqlQuery.setQuery(the_query)
-    return sparqlQuery.query().convert()
+    try:
+        return sparqlQuery.query().convert()
+    except Exception as e:
+        logger.error("(AGENT) The following query caused an exception to be thrown: \n" + the_query)
+        raise e
 
 
 def update(the_query):
@@ -36,5 +41,10 @@ def update(the_query):
     if the given query is no update query, nothing happens."""
     sparqlUpdate.setQuery(the_query)
     if sparqlUpdate.isSparqlUpdateRequest():
-        log("(agent update) execute query: \n" + the_query)
-        sparqlUpdate.query()
+        if LOG_SPARQL_UPDATES:
+            logger.info("(AGENT) Execute update: \n" + the_query)
+        try:
+            sparqlUpdate.query()
+        except Exception as e:
+            logger.error("(AGENT) The following query caused an exception to be thrown: \n" + the_query)
+            raise e

--- a/authentication.py
+++ b/authentication.py
@@ -2,7 +2,7 @@ import os
 from functools import wraps
 
 from flask import g, request
-from helpers import error, generate_uuid, log, logger
+from helpers import error, generate_uuid, logger
 from signinghub_api_client.client import SigningHubSession
 from signinghub_api_client.exceptions import AuthenticationException
 
@@ -36,14 +36,14 @@ def get_or_create_signinghub_session(mu_session_uri):
     sh_session_results = sudo_query(sh_session_query)['results']['bindings']
     sh_session = None
     if sh_session_results: # Restore SigningHub session
-        log("Found a valid SigningHub session.")
+        logger.debug("Found a valid SigningHub session.")
         sh_session_result = sh_session_results[0]
         sh_session = SigningHubSession(SIGNINGHUB_API_URL)
         if CLIENT_CERT_AUTH_ENABLED:
             sh_session.cert = (CERT_FILE_PATH, KEY_FILE_PATH) # For authenticating against VO-network
         sh_session.access_token = sh_session_result["token"]["value"]
     else: # Open new SigningHub session
-        log("No valid SigningHub session found. Opening a new one ...")
+        logger.debug("No valid SigningHub session found. Opening a new one ...")
         sh_session = open_new_signinghub_machine_user_session(mu_session["ovoCode"]["value"], mu_session["email"]["value"])
         sh_session_uri = SIGNINGHUB_SESSION_BASE_URI + generate_uuid()
         sh_session_query = construct_insert_signinghub_session_query(sh_session, sh_session_uri)
@@ -70,7 +70,7 @@ def open_new_signinghub_machine_user_session(ovo_code, scope=None):
 
 
 def set_signinghub_machine_user_session(session):
-    log("Found a valid SigningHub session.")
+    logger.debug("Found a valid SigningHub session.")
     g.sh_session = SigningHubSession(SIGNINGHUB_API_URL)
     if CLIENT_CERT_AUTH_ENABLED:
         g.sh_session.cert = (CERT_FILE_PATH, KEY_FILE_PATH) # For authenticating against VO-network
@@ -78,7 +78,7 @@ def set_signinghub_machine_user_session(session):
 
 
 def create_signinghub_machine_user_session(scope, ovo_code):
-    log("No valid SigningHub session found. Opening a new one ...")
+    logger.debug("No valid SigningHub session found. Opening a new one ...")
     sh_session = open_new_signinghub_machine_user_session(ovo_code, scope)
     sh_session_uri = SIGNINGHUB_SESSION_BASE_URI + generate_uuid()
     sh_session_query = construct_insert_signinghub_session_query(sh_session, sh_session_uri, scope)

--- a/authentication.py
+++ b/authentication.py
@@ -8,16 +8,16 @@ from signinghub_api_client.exceptions import AuthenticationException
 
 from .authentication_config import MACHINE_ACCOUNTS
 from .config import KALEIDOS_RESOURCE_BASE_URI
-from .lib.exceptions import NoQueryResultsException
 from .queries.session import (
     construct_attach_signinghub_session_to_mu_session_query,
-    construct_get_mu_session_query, construct_get_org_for_email,
+    construct_get_org_for_email,
     construct_get_signinghub_machine_user_session_query,
     construct_get_signinghub_session_query,
     construct_insert_signinghub_session_query,
     construct_mark_signinghub_session_as_machine_users_query)
 from .sudo_query import query as sudo_query
 from .sudo_query import update as sudo_update
+from .lib.session import get_mu_session
 
 SIGNINGHUB_API_URL = os.environ.get("SIGNINGHUB_API_URL")
 CERT_FILE_PATH = os.environ.get("CERT_FILE_PATH")
@@ -27,11 +27,7 @@ CLIENT_CERT_AUTH_ENABLED = CERT_FILE_PATH and KEY_FILE_PATH
 SIGNINGHUB_SESSION_BASE_URI = KALEIDOS_RESOURCE_BASE_URI + "id/signinghub-sessions/"
 
 def get_or_create_signinghub_session(mu_session_uri):
-    mu_session_query = construct_get_mu_session_query(mu_session_uri)
-    mu_session_result = sudo_query(mu_session_query)['results']['bindings']
-    if not mu_session_result:
-        raise NoQueryResultsException("Didn't find a mu-session associated with an account with email-address and supported ovo-code")
-    mu_session = mu_session_result[0]
+    mu_session = get_mu_session(mu_session_uri)
     sh_session_query = construct_get_signinghub_session_query(mu_session_uri)
     sh_session_results = sudo_query(sh_session_query)['results']['bindings']
     sh_session = None

--- a/lib/file.py
+++ b/lib/file.py
@@ -48,7 +48,7 @@ def fs_sanitize_filename(filename, replace_char=""):
 def delete_physical_file(physical_file_uri):
     path = physical_file_uri.replace("share://", "/share/")
     if os.path.exists(path):
-        logger.info(f"Removing file: {path}")
+        logger.debug(f"Removing file: {path}")
         os.remove(path)
     else:
         logger.debug(f"Tried removing file {path} but could not find it")

--- a/lib/job.py
+++ b/lib/job.py
@@ -26,7 +26,7 @@ def create_job(sign_flow_uris, mu_session_uri):
     uuid = generate_uuid()
     uri = f"{JOB_RESOURCE_BASE_URI}{uuid}"
     now = datetime.now()
-    logger.info(
+    logger.debug(
         f"Creating job with uri {sparql_escape_uri(uri)} for {len(sign_flow_uris)} sign flows"
     )
 
@@ -165,11 +165,10 @@ def execute_job(job):
         execute_prepare_sign_flow_job(job)
         update_job_status(job["uri"], JOB["STATUSES"]["SUCCESS"])
 
-        logger.info("**************************************")
         logger.info(f"Successfully finished job <{job['uri']}>")
-        logger.info("**************************************")
     except Exception as e:
-        logger.exception(f"Execution of job <{job['uri']}> failed:")
+        logger.exception(f"Failed to execute job <{job['uri']}>: {e}")
+
         update_job_status(job["uri"], JOB["STATUSES"]["FAILED"])
         error_message = str(e)
         update_job_error_message(

--- a/lib/job.py
+++ b/lib/job.py
@@ -11,9 +11,12 @@ from string import Template
 
 from ..authentication import get_or_create_signinghub_session
 from ..agent_query import query as agent_query, update as agent_update
+
+from .session import get_mu_session
 from .file import delete_physical_file
 from .prepare_signing_flow import prepare_signing_flow
 from .query_result_helpers import to_recs
+
 from ..queries.signing_flow import (
     construct_get_signing_flows_by_uris,
     get_physical_files_of_sign_flows,
@@ -161,6 +164,12 @@ INSERT DATA {
 
 def execute_job(job):
     try:
+        mu_session_uri = job["mu_session_uri"]
+        mu_session = get_mu_session(mu_session_uri)
+        email = mu_session["email"]["value"]
+
+        logger.info(f"Starting execution of job <{job['uri']}> started by user {email}")
+
         update_job_status(job["uri"], JOB["STATUSES"]["BUSY"])
         execute_prepare_sign_flow_job(job)
         update_job_status(job["uri"], JOB["STATUSES"]["SUCCESS"])

--- a/lib/prepare_signing_flow.py
+++ b/lib/prepare_signing_flow.py
@@ -101,7 +101,7 @@ def prepare_signing_flow(
         # sign flow to get them.
         approvers = signing_flow.get_approvers(sign_flow, query_method)
         for approver in approvers:
-            logger.info(f"adding approver {approver['email']} to flow")
+            logger.debug(f"adding approver {approver['email']} to flow")
             sh_session.add_users_to_workflow(package_id, [{
             "user_email": approver["email"],
             "user_name": approver["email"],
@@ -112,7 +112,7 @@ def prepare_signing_flow(
 
         notified = signing_flow.get_notified(sign_flow, query_method)
         for notify in notified:
-            logger.info(f"adding notified {notify['email']} to flow")
+            logger.debug(f"adding notified {notify['email']} to flow")
             sh_session.add_users_to_workflow(package_id, [{
             "user_email": notify["email"],
             "user_name": notify["email"],
@@ -124,7 +124,7 @@ def prepare_signing_flow(
         signers = signing_flow.get_signers(sign_flow, query_method)
         signer_mandatees = []
         for signer in signers:
-            logger.info(f"adding signer {signer['uri']} to flow")
+            logger.debug(f"adding signer {signer['uri']} to flow")
             signer = get_mandatee(signer["uri"], query_method)
             signer_mandatees.append(signer)
             sh_session.add_users_to_workflow(package_id, [{
@@ -184,12 +184,12 @@ def auto_place_signature(
     auto_place_order,
     sh_session
 ):
-    logger.info((
+    logger.debug((
         f"auto-placing signature field for "
         f"{piece_uri} {package_id} {signinghub_document_id}"
     ))
     for index, mandatee in enumerate(signer_mandatees):
-        logger.info(f"placing field for signer {mandatee}")
+        logger.debug(f"placing field for signer {mandatee}")
         sh_data = {
             "search_text": (
                 f"{mandatee['first_name']} "

--- a/lib/session.py
+++ b/lib/session.py
@@ -1,0 +1,11 @@
+from .exceptions import NoQueryResultsException
+from ..sudo_query import query as sudo_query
+from ..queries.session import construct_get_mu_session_query
+
+def get_mu_session(mu_session_uri):
+    mu_session_query = construct_get_mu_session_query(mu_session_uri)
+    mu_session_result = sudo_query(mu_session_query)['results']['bindings']
+    if not mu_session_result:
+        raise NoQueryResultsException("Didn't find a mu-session associated with an account with email-address and supported ovo-code")
+    mu_session = mu_session_result[0]
+    return mu_session

--- a/lib/update_signing_flow.py
+++ b/lib/update_signing_flow.py
@@ -147,7 +147,7 @@ def sync_approvers_status(sig_flow, sh_workflow_details):
                     if not kaleidos_approver["start_date"]:
                         # The flow has been shared, we can set the start time of the approval activity based on the modified_on field
                         start_time = pythonize_iso_timestamp(sh_workflow_details["modified_on"])
-                        logger.info(f"Approver {kaleidos_approver['email']} ready to approve. Syncing start date {start_time} ...")
+                        logger.debug(f"Approver {kaleidos_approver['email']} ready to approve. Syncing start date {start_time} ...")
                         query_string = construct_update_approval_activity_start_date(
                             sig_flow,
                             kaleidos_approver["email"],
@@ -155,14 +155,14 @@ def sync_approvers_status(sig_flow, sh_workflow_details):
                         agent_update(query_string)
                 elif proc_stat == "REVIEWED":
                     approval_time = pythonize_iso_timestamp(sh_workflow_user["processed_on"])
-                    logger.info(f"Approver {kaleidos_approver['email']} approved. Syncing end date {approval_time} ...")
+                    logger.debug(f"Approver {kaleidos_approver['email']} approved. Syncing end date {approval_time} ...")
                     query_string = construct_update_approval_activity_end_date(
                         sig_flow,
                         kaleidos_approver["email"],
                         datetime.fromisoformat(approval_time))
                     agent_update(query_string)
                 elif proc_stat == "DECLINED":
-                    logger.info(f"Approver {kaleidos_approver['email']} refused. Syncing ...")
+                    logger.debug(f"Approver {kaleidos_approver['email']} refused. Syncing ...")
                     refusal_time = pythonize_iso_timestamp(sh_workflow_user["processed_on"])
                     query_string = construct_insert_approval_refusal_activity(
                         sig_flow,
@@ -172,9 +172,9 @@ def sync_approvers_status(sig_flow, sh_workflow_details):
                 else:
                     logger.warn(f"Approver {kaleidos_approver['email']} encountered unknown process status {sh_workflow_user['process_status']}. Skipping ...")
             else:
-                logger.info(f"Approver {kaleidos_approver['email']} already has an end date in our db. No syncing needed.")
+                logger.debug(f"Approver {kaleidos_approver['email']} already has an end date in our db. No syncing needed.")
         else:
-            logger.info(f"Approver with e-mail address {sh_workflow_user['user_email']} not present in Kaleidos metadata: Adding.")
+            logger.debug(f"Approver with e-mail address {sh_workflow_user['user_email']} not present in Kaleidos metadata: Adding.")
             # insert approver with minimal info. Further details (dates, completion status, ...)
             # will get picked up on a next pass in the SH -> Kaleidos sync direction.
             query_string = construct_insert_approval_activity(sig_flow, sh_workflow_user['user_email'])
@@ -198,14 +198,14 @@ def sync_signers_status(sig_flow, sh_workflow_details):
                 if proc_stat == "IN_PROGRESS":
                     if not kaleidos_signer["start_date"]:
                         start_time = pythonize_iso_timestamp(sh_workflow_details["modified_on"])
-                        logger.info(f"Signer {kaleidos_signer['email']} ready to sign. Syncing start date {start_time} ...")
+                        logger.debug(f"Signer {kaleidos_signer['email']} ready to sign. Syncing start date {start_time} ...")
                         query_string = construct_update_signing_activity_start_date(
                             sig_flow,
                             kaleidos_signer["uri"],
                             datetime.fromisoformat(start_time))
                         agent_update(query_string)
                 elif proc_stat == "SIGNED":
-                    logger.info(f"Signer {kaleidos_signer['email']} signed. Syncing ...")
+                    logger.debug(f"Signer {kaleidos_signer['email']} signed. Syncing ...")
                     signing_time = pythonize_iso_timestamp(sh_workflow_user["processed_on"])
                     query_string = construct_update_signing_activity_end_date(
                         sig_flow,
@@ -213,7 +213,7 @@ def sync_signers_status(sig_flow, sh_workflow_details):
                         datetime.fromisoformat(signing_time))
                     agent_update(query_string)
                 elif proc_stat == "DECLINED":
-                    logger.info(f"Signer {kaleidos_signer['email']} refused. Syncing ...")
+                    logger.debug(f"Signer {kaleidos_signer['email']} refused. Syncing ...")
                     refusal_time = pythonize_iso_timestamp(sh_workflow_user["processed_on"])
                     query_string = construct_insert_signing_refusal_activity(
                         sig_flow,
@@ -223,6 +223,7 @@ def sync_signers_status(sig_flow, sh_workflow_details):
                 else:
                     logger.warn(f"Unknown process status {sh_workflow_user['process_status']}. Skipping ...")
             else:
-                logger.info(f"Signer {kaleidos_signer['email']} already has an end date in our db. No syncing needed.")
+                logger.debug(f"Signer {kaleidos_signer['email']} already has an end date in our db. No syncing needed.")
         else:
-            logger.info(f"Signer with e-mail address {sh_workflow_user['user_email']} not present in Kaleidos metadata: ignoring")
+            logger.debug(f"Signer with e-mail address {sh_workflow_user['user_email']} not present in Kaleidos metadata: ignoring")
+    return False

--- a/sudo_query.py
+++ b/sudo_query.py
@@ -1,6 +1,6 @@
 import os
 
-from helpers import log
+from helpers import logger, LOG_SPARQL_QUERIES, LOG_SPARQL_UPDATES
 from SPARQLWrapper import JSON, SPARQLWrapper
 
 sparqlQuery = SPARQLWrapper(os.environ.get('MU_SPARQL_ENDPOINT'), returnFormat=JSON)
@@ -13,9 +13,14 @@ sparqlUpdate.addCustomHttpHeader('mu-auth-sudo', 'true')
 def query(the_query):
     """Execute the given SPARQL query (select/ask/construct)on the triple store and returns the results
     in the given returnFormat (JSON by default)."""
-    log("(sudo query) execute query: \n" + the_query)
+    if LOG_SPARQL_QUERIES:
+        logger.info("(SUDO) Execute query: \n" + the_query)
     sparqlQuery.setQuery(the_query)
-    return sparqlQuery.query().convert()
+    try:
+        return sparqlQuery.query().convert()
+    except Exception as e:
+        logger.error("(SUDO) The following query caused an exception to be thrown: \n" + the_query)
+        raise e
 
 
 def update(the_query):
@@ -23,5 +28,10 @@ def update(the_query):
     if the given query is no update query, nothing happens."""
     sparqlUpdate.setQuery(the_query)
     if sparqlUpdate.isSparqlUpdateRequest():
-        log("(sudo update) execute query: \n" + the_query)
-        sparqlUpdate.query()
+        if LOG_SPARQL_UPDATES:
+            logger.info("(SUDO) Execute update: \n" + the_query)
+        try:
+            sparqlUpdate.query()
+        except Exception as e:
+            logger.error("(SUDO) The following query caused an exception to be thrown: \n" + the_query)
+            raise e

--- a/web.py
+++ b/web.py
@@ -107,10 +107,10 @@ def prepare_post():
 @app.route('/signing-flows/<signflow_id>', methods=['DELETE'])
 def signinghub_remove_signflow(signflow_id):
     physical_files = to_recs(query(get_physical_files_of_sign_flows_by_id([signflow_id])))
+    update(remove_signflows([signflow_id]))
     for physical_file in physical_files:
         delete_physical_file(physical_file["uri"])
         update(delete_physical_file_metadata(physical_file["uri"]))
-    update(remove_signflows([signflow_id]))
     # Give cache time to update
     # Ideally we want to return the changed values so the frontend
     # can update without refetching the new data.

--- a/web.py
+++ b/web.py
@@ -144,7 +144,11 @@ def signinghub_integration_url(signflow_id, piece_id):
 @app.route('/signing-flows/<signflow_id>/sync', methods=['POST'])
 def signinghub_sync(signflow_id):
     signflow_uri = get_by_uuid(signflow_id, None, agent_query)
-    update_signing_flow(signflow_uri)
+    new_status = update_signing_flow(signflow_uri)
+    if new_status:
+        logger.info(f"Status for signflow <{signflow_uri}> was changed to {new_status}")
+    else:
+        logger.info(f"Status for signflow <{signflow_uri}> was left unchanged")
     return make_response({}, 200)
 
 

--- a/web.py
+++ b/web.py
@@ -43,7 +43,7 @@ def sh_profile_info():
     for ovo_code in MACHINE_ACCOUNTS.keys():
         try:
             open_new_signinghub_machine_user_session(ovo_code)
-            logger.info(f"Successful login for machine user account of {ovo_code} ({MACHINE_ACCOUNTS[ovo_code]['USERNAME']})")
+            logger.debug(f"Successful login for machine user account of {ovo_code} ({MACHINE_ACCOUNTS[ovo_code]['USERNAME']})")
             # sh_session.logout() doesn't work. https://manuals.ascertia.com/SigningHub/8.2/Api/#tag/Authentication/operation/V4_Account_LogoutUser specifies a (required?) device token which we don't have
         except Exception as e:
             response_code = 500

--- a/web.py
+++ b/web.py
@@ -27,9 +27,11 @@ from .queries.file import delete_physical_file_metadata
 
 def sync_all_ongoing_flows():
     records = signing_flow.get_ongoing_signing_flows(agent_query)
+    logger.info(f"Starting synchronisation for {len(records)} signflows...")
     ids = list(map(lambda r: r["sign_flow_id"], records))
     for id in ids:
         requests.post(f"http://localhost/signing-flows/{id}/sync")
+    logger.info("Synchronisation finished")
 
 scheduler = BackgroundScheduler()
 scheduler.add_job(sync_all_ongoing_flows, CronTrigger.from_crontab(SYNC_CRON_PATTERN))


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4644

This PR:

- Updates the template to a feature branch which disables SPARQL logs except in case of query failure
- Updates the sudo & agent query wrappers from our service code to also disable SPARQL logs except in case of query failure
- Replaces all existing `logger.info` calls with `logger.debug` calls, which can be enabled by setting the environment variable `LOG_LEVEL=debug`
- Logs the user who started a signing flow submission job (their email address)
- Extracts a little bit of code for getting the mu session to a a new function
- Adds some short and simplified logging for starting and syncing singing flows