### PR TITLE
KAS-4953: Add service endpoint to clear siigning hub sessions

### DIFF
--- a/queries/session.py
+++ b/queries/session.py
@@ -166,6 +166,25 @@ WHERE {
         mu_session=sparql_escape_uri(mu_session_uri))
     return query_string
 
+def construct_delete_signinghub_sessions():
+    query_template = Template("""
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX oauth-2.0: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE WHERE {
+    GRAPH $session_graph {
+        ?signinghubSession a oauth-2.0:OauthSession, ?type ;
+            oauth-2.0:hasTokenValue ?tokenUri ;
+            ?p ?o .
+        ?tokenUri ?p_ ?o_ .
+    }
+}""")
+
+    query_string = query_template.substitute(session_graph=sparql_escape_uri(SESSION_GRAPH))
+    return query_string
+
 def construct_mark_signinghub_session_as_machine_users_query(signinghub_session_uri):
     # TODO: this is a hacky way of marking the machine user session.
     # Should think about way to model the service as an agent (with a mu session?)

--- a/web.py
+++ b/web.py
@@ -12,6 +12,7 @@ from helpers import error, logger, query, validate_json_api_content_type, update
 from lib.query_result_helpers import to_recs
 
 from .agent_query import query as agent_query
+from .sudo_query import update as sudo_update
 from .authentication import (MACHINE_ACCOUNTS,
                              open_new_signinghub_machine_user_session)
 from .config import SIGNINGHUB_APP_DOMAIN, SYNC_CRON_PATTERN
@@ -23,6 +24,7 @@ from .lib.file import delete_physical_file
 from .lib.job import create_job, execute_job, get_job
 from .queries.signing_flow import get_physical_files_of_sign_flows_by_id, remove_signflows
 from .queries.file import delete_physical_file_metadata
+from .queries.session import construct_delete_signinghub_sessions
 
 
 def sync_all_ongoing_flows():
@@ -63,6 +65,17 @@ def sh_profile_info():
         response.status_code = 500
         response.headers["Content-Type"] = "application/vnd.api+json"
         return response
+
+
+# Service endpoint, should only be accessed from the service container
+# In a hostend environment, execute the following command to fire this endpoint:
+# > drc exec digital-signing curl -XDELETE http://localhost/sessions
+# This endpoint should not be made available via the dispatcher, as it doesn't check the current session's rights
+@app.route('/sessions', methods=['DELETE'])
+def delete_sessions():
+    delete_sessions_query = construct_delete_signinghub_sessions()
+    sudo_update(delete_sessions_query)
+    return make_response("", 204)
 
 
 @app.route('/job/<job_id>')


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4953

Adds a new endpoint that deletes all SigningHub Sessions from the sessions graph. This endpoint uses a sudo query, but it's not made available via the dispatcher so it isn't reachable outside of the server. Usage of this endpoint is described in a comment in the code:

> In a hostend environment, execute the following command to fire this endpoint:
> `drc exec digital-signing curl -XDELETE http://localhost/sessions`
