### PR TITLE
KAS-4953: Split up delete sessions query into paginated queries

### DIFF
--- a/queries/session.py
+++ b/queries/session.py
@@ -166,20 +166,40 @@ WHERE {
         mu_session=sparql_escape_uri(mu_session_uri))
     return query_string
 
+def construct_ask_if_signinghub_sessions_exist():
+    query_template = Template("""
+PREFIX oauth-2.0: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
+
+ASK WHERE {
+    GRAPH $session_graph {
+        ?signinghubSession a oauth-2.0:OauthSession ;
+            oauth-2.0:hasTokenValue ?tokenUri .
+    }
+}""")
+
+    query_string = query_template.substitute(session_graph=sparql_escape_uri(SESSION_GRAPH))
+    return query_string
+
 def construct_delete_signinghub_sessions():
     query_template = Template("""
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX oauth-2.0: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
-DELETE WHERE {
+DELETE {
     GRAPH $session_graph {
-        ?signinghubSession a oauth-2.0:OauthSession, ?type ;
-            oauth-2.0:hasTokenValue ?tokenUri ;
-            ?p ?o .
+        ?signinghubSession ?p ?o .
         ?tokenUri ?p_ ?o_ .
     }
+}
+WHERE {
+    { SELECT ?signinghubSession ?p ?o ?tokenUri ?p_ ?o_
+      WHERE {
+        GRAPH $session_graph {
+            ?signinghubSession a oauth-2.0:OauthSession, ?type ;
+                oauth-2.0:hasTokenValue ?tokenUri ;
+                ?p ?o .
+            ?tokenUri ?p_ ?o_ .
+        }
+      } LIMIT 1000 }
 }""")
 
     query_string = query_template.substitute(session_graph=sparql_escape_uri(SESSION_GRAPH))


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4953

With production data, the query to delete everything was too slow for sparql-parser, because it's having to handle too much data. Instead, we make the query perform the operation in a paginated way.